### PR TITLE
Make syslog dependency optional

### DIFF
--- a/email2pdf
+++ b/email2pdf
@@ -91,6 +91,11 @@ def main(argv, sysLogHandler, sysErrHandler):
                         "or autogenerate a filename. If this option is specified, it will instead ignore "
                         "them.")
 
+    parser.add_argument("--enforce-syslog", action="store_true",
+                        help="By default email2pdf will use syslog if available and just log to stderr "
+                        "if not. If this option is specified, it will instead fail when the syslog socket "
+                        "can not be located")
+
     parser.add_argument('-v', '--verbose', action='count', default=0,
                         help="Make the output more verbose. This affects both the output logged to "
                         "syslog, as well as output to the console. Using this twice makes it doubly verbose.")
@@ -103,6 +108,9 @@ def main(argv, sysLogHandler, sysErrHandler):
     if args.help:
         parser.print_help()
         return
+
+    if args.enforce_syslog and not sysLogHandler:
+        raise FatalException("Required syslog socket was not found")
 
     if sysLogHandler:
         if args.verbose > 1:

--- a/email2pdf
+++ b/email2pdf
@@ -478,14 +478,16 @@ if __name__ == "__main__":
     elif _platform == "darwin":
         sysLogAddress = '/var/run/syslog'
     else:
-        print("Unsupported platform.")
-        sys.exit(3)
+        sysLogAddress = None
 
-    sysLogHandler = logging.handlers.SysLogHandler(address=sysLogAddress)
-    sysLogHandler.setLevel(logging.INFO)
-    sysLogFormatter = logging.Formatter('%(pathname)s[%(process)d] %(levelname)s %(lineno)d %(message)s')
-    sysLogHandler.setFormatter(sysLogFormatter)
-    logger.addHandler(sysLogHandler)
+    if sysLogAddress and os.path.exists(sysLogAddress):
+        sysLogHandler = logging.handlers.SysLogHandler(address=sysLogAddress)
+        sysLogHandler.setLevel(logging.INFO)
+        sysLogFormatter = logging.Formatter('%(pathname)s[%(process)d] %(levelname)s %(lineno)d %(message)s')
+        sysLogHandler.setFormatter(sysLogFormatter)
+        logger.addHandler(sysLogHandler)
+    else:
+        sysLogHandler = None
 
     sysErrHandler = logging.StreamHandler(stream=sys.stderr)
     sysErrHandler.setLevel(logging.WARNING)


### PR DESCRIPTION
Sometimes it is nice to be able to run email2pdf without requiring that
a syslog socket first be available or to be able to run it even if we
don't know the location of the syslog socket. This commit simply makes
the syslog requirement optional so that email2pdf only outputs to
stderr if it can't find a syslog socket.