### PR TITLE
close file handle to prevent file being locked (win32)

### DIFF
--- a/email2pdf
+++ b/email2pdf
@@ -530,7 +530,8 @@ def add_update_pdf_metadata(filename, update_dictionary):
             assert full_update_dictionary[key] is not None
             info_dict.update({NameObject(key): createStringObject(full_update_dictionary[key])})
 
-        _, temp_file_name = tempfile.mkstemp(prefix="email2pdf_add_update_pdf_metadata", suffix=".pdf")
+        os_file_out, temp_file_name = tempfile.mkstemp(prefix="email2pdf_add_update_pdf_metadata", suffix=".pdf")
+        os.close(os_file_out)
 
         with open(temp_file_name, 'wb') as file_out:
             pdf_output.write(file_out)


### PR DESCRIPTION
I was getting a PermissionError in windows because there was still a handle to the temp file left open, causing the subsequent move to fail.