### PR TITLE
HTML-escape email header content

### DIFF
--- a/email2pdf
+++ b/email2pdf
@@ -649,7 +649,8 @@ def get_formatted_header_info(input_email):
     for header in FORMATTED_HEADERS_TO_INCLUDE:
         if input_email[header]:
             decoded_string = get_utf8_header(input_email[header])
-            header_info = header_info + '<b>' + header + '</b>: ' + decoded_string + '<br/>'
+            header_info = header_info + '<b>' + header + '</b>: ' + \
+                          html.escape(decoded_string) + '<br/>'
 
     return header_info + '<br/>'
 


### PR DESCRIPTION
Adding plain email headers into html may cause problems.
Consider the following header:

    To: Frank Seifferth <frankseifferth@posteo.net>

If its content isn't escaped properly, the actual email
address will be interpreted as an unknown tag by wkhtmltopdf
and will thus be skipped. This fix causes the above example
to be rendered correctly.