### PR TITLE
Wrap long lines in plain text mail bodies

### DIFF
--- a/email2pdf
+++ b/email2pdf
@@ -23,6 +23,7 @@ import re
 import shutil
 import sys
 import tempfile
+import textwrap
 import traceback
 
 from PyPDF2 import PdfFileReader, PdfFileWriter
@@ -342,6 +343,9 @@ def handle_plain_message_body(part):
         if isinstance(payload, bytes):
             payload = str(payload, charset)
 
+        payload = "\n".join(    # Wrap long lines, individually
+            [ textwrap.fill(line, width=80) for line in payload.splitlines() ]
+        )
         payload = html.escape(payload)
         payload = "<html><body><pre>\n" + payload + "\n</pre></body></html>"
 


### PR DESCRIPTION
Afaik, lines in plain text emails *should* be wrapped at
80 characters. Unfortunately, not all of them are. Wrapping
long lines in `pre` tags might cause them to be truncated
at the page margin. This patch wraps each individual line
in plain text body parts at 80 characters. Well formatted
body parts will thus appear unchanged while badly formatted
lines will be wrapped to comfortably fit the page.

Note: Depending on the output pdf's page size, lines with
more than 80 characters may still fit the page. I still
believe that 80 characters are a good choice, though, since
they are the suggested line length for plain text emails.