### PR TITLE
Use list for FORMATTED_HEADERS_TO_INCLUDE

### DIFF
--- a/email2pdf
+++ b/email2pdf
@@ -38,7 +38,7 @@ HEADER_MAPPING = {'Author': 'From',
                   'Title': 'Subject',
                   'X-email2pdf-To': 'To'}
 
-FORMATTED_HEADERS_TO_INCLUDE = frozenset(['Subject', 'From', 'To', 'Date'])
+FORMATTED_HEADERS_TO_INCLUDE = ['Subject', 'From', 'To', 'Date']
 
 MIME_TYPES_BLACKLIST = frozenset(['text/html', 'text/plain'])
 


### PR DESCRIPTION
Using a frozenset for headers to include might cause the
order of these headers to change with each invocation of
email2pdf. (And it does on my system.) I would therefore
suggest using a data structure that has an order. This
guarantees that iterating over headers will always yield
them in the same order.