### PR TITLE
Set up use as a library

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+include email2pdf
+include *.py
+include *.md
+include .travis.yml

--- a/email2pdf.py
+++ b/email2pdf.py
@@ -1,0 +1,1 @@
+email2pdf

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,19 @@
+from setuptools import setup
+
+setup(
+    name='email2pdf',
+    version='',
+    packages=['tests', 'tests.Direct', 'tests.Subprocess'],
+    url='https://github.com/andrewferrier/email2pdf',
+    license='MIT',
+    author='Andrew Ferrier',
+    description='email2pdf is a Python script to convert emails to PDF.',
+    install_requires=[
+        'beautifulsoup4>=4.6.3',
+        'html5lib',
+        'lxml',
+        'pypdf2',
+        'python-magic',
+        'reportlab',
+    ],
+)

--- a/tests/Direct/test_Direct_Module.py
+++ b/tests/Direct/test_Direct_Module.py
@@ -1,0 +1,10 @@
+from tests import BaseTestClasses
+
+
+class Direct_Module(BaseTestClasses.Email2PDFTestCase):
+    def setUp(self):
+        super(Direct_Module, self).setUp()
+
+    def test_import(self):
+        import email2pdf
+        self.assertEqual(email2pdf.WKHTMLTOPDF_EXTERNAL_COMMAND, 'wkhtmltopdf')


### PR DESCRIPTION
Following issue #97, I have added the basics so that the module can be installed as a developped package.
It can be registered it on Pypi when appropriate.

note: I'm not pleased with the symlink `email2pdf.py`, but it's an easy way to keep backward compatibility.